### PR TITLE
Change viewport scale to 1 for mobile devices

### DIFF
--- a/components/alheimsins/Layout.js
+++ b/components/alheimsins/Layout.js
@@ -6,7 +6,7 @@ export default ({ user, children }) => (
   <div className='container'>
     <Head>
       <title>Free open-source BigFive personality traits test - translated to multiple languages</title>
-      <meta name='viewport' content='initial-scale=0.8, maximum-scale=0.8, width=device-width' />
+      <meta name='viewport' content='initial-scale=1, maximum-scale=1, width=device-width' />
       <meta property='og:title' content='Want to take a free Big Five personality test?' />
       <meta property='og:description' content='Take a free, open-source Big Five personality test - translated to multiple languages. Get to know yourself better from a detailed profile of your personality traits or learn to know others by comparing yourself with your partner, colleagues, friends or family.' />
       <meta property='og:image' content='/static/apple-icon-152x152.png' />

--- a/components/alheimsins/Layout.js
+++ b/components/alheimsins/Layout.js
@@ -6,7 +6,7 @@ export default ({ user, children }) => (
   <div className='container'>
     <Head>
       <title>Free open-source BigFive personality traits test - translated to multiple languages</title>
-      <meta name='viewport' content='initial-scale=1, maximum-scale=5, width=device-width' user-scalable="yes"/>
+      <meta name='viewport' content='initial-scale=1, maximum-scale=5, width=device-width' user-scalable='yes' />
       <meta property='og:title' content='Want to take a free Big Five personality test?' />
       <meta property='og:description' content='Take a free, open-source Big Five personality test - translated to multiple languages. Get to know yourself better from a detailed profile of your personality traits or learn to know others by comparing yourself with your partner, colleagues, friends or family.' />
       <meta property='og:image' content='/static/apple-icon-152x152.png' />

--- a/components/alheimsins/Layout.js
+++ b/components/alheimsins/Layout.js
@@ -6,7 +6,7 @@ export default ({ user, children }) => (
   <div className='container'>
     <Head>
       <title>Free open-source BigFive personality traits test - translated to multiple languages</title>
-      <meta name='viewport' content='initial-scale=1, maximum-scale=1, width=device-width' />
+      <meta name='viewport' content='initial-scale=1, maximum-scale=5, width=device-width' user-scalable="yes"/>
       <meta property='og:title' content='Want to take a free Big Five personality test?' />
       <meta property='og:description' content='Take a free, open-source Big Five personality test - translated to multiple languages. Get to know yourself better from a detailed profile of your personality traits or learn to know others by comparing yourself with your partner, colleagues, friends or family.' />
       <meta property='og:image' content='/static/apple-icon-152x152.png' />


### PR DESCRIPTION
Closes #75 

**Changes**
- Change value from `meta:viewport` from `0.8` to `1`.
- Enable `user-scalable` property for more accessibility

**Proof**
![image](https://user-images.githubusercontent.com/6183307/46766896-f8783680-cca8-11e8-9e73-c0ef5f040a0a.png)
